### PR TITLE
Correct path for repo.

### DIFF
--- a/setup-mac-os.sh
+++ b/setup-mac-os.sh
@@ -4,7 +4,7 @@
 
 # failed on first try with: REPO=~/github/mac-init
 # TODO: try adding mac-init.git
-REPO=~/github/mac-init/mac-init.git
+REPO=~/github/mac-init/
 
 BREW_FILE_PATH="${REPO}/brew/macOS.Brewfile"
 # BREW_FILE_PATH="${REPO}/brew/debug.Brewfile"    #debug


### PR DESCRIPTION
This had resulted in `~/github/mac-init/mac-init.git/[repo]`. 
Wanted: `~/github/mac-init/[repo]`.